### PR TITLE
Padronização de exportações usando CommonJS no front-end

### DIFF
--- a/Front-end/src/app/core/interfaces/IApiService.js
+++ b/Front-end/src/app/core/interfaces/IApiService.js
@@ -49,4 +49,4 @@ class IApiService {
     }
 }
 
-export default IApiService;
+module.exports = IApiService;

--- a/Front-end/src/app/core/utils/AsyncUtils.js
+++ b/Front-end/src/app/core/utils/AsyncUtils.js
@@ -147,4 +147,4 @@ class AsyncUtils {
     }
 }
 
-export default AsyncUtils;
+module.exports = AsyncUtils;


### PR DESCRIPTION
Este pull request modifica a sintaxe de exportação de dois arquivos principais da base de código front-end, migrando de `export default` (ES6) para `module.exports` (CommonJS).
